### PR TITLE
NDEV-2428: Fix tracer tests and run them concurrently

### DIFF
--- a/clickfile.py
+++ b/clickfile.py
@@ -507,7 +507,7 @@ def run(name, jobs, numprocesses, ui_item, amount, users, network):
         if numprocesses:
             command = f"{command} --numprocesses {numprocesses} --dist loadgroup"
     elif name == "tracer":
-        command = "py.test integration/tests/tracer"
+        command = "py.test -n 50 integration/tests/tracer"
     elif name == "services":
         command = "py.test integration/tests/services"
         if numprocesses:

--- a/integration/tests/tracer/schemas/debug_traceCall.json
+++ b/integration/tests/tracer/schemas/debug_traceCall.json
@@ -81,9 +81,7 @@
                         "gas",
                         "gasCost",
                         "op",
-                        "pc",
-                        "returnData",
-                        "stack"
+                        "pc"
                     ]
                 }
             ]


### PR DESCRIPTION
- Run tracer tests concurrently using `pytest-xdist`. Reduced test time from almost [21m 20s](https://github.com/neonlabsorg/tracer-api/actions/runs/6970492670/job/18968799903) to just [4m 44s](https://github.com/neonlabsorg/tracer-api/actions/runs/7139579907/job/19443444654?pr=93)
- Fixed tracer tests.