### PR TITLE
Remove is_mutable check for Metaplex metadata

### DIFF
--- a/integration/tests/basic/erc/test_ERC20SPL.py
+++ b/integration/tests/basic/erc/test_ERC20SPL.py
@@ -57,14 +57,12 @@ class TestERC20wrapperContract:
         metadata = metaplex.get_metadata(self.sol_client, mint_key)
         assert metadata["data"]["name"] == erc20_spl_mintable.name
         assert metadata["data"]["symbol"] == erc20_spl_mintable.symbol
-        assert metadata["is_mutable"] is False
 
     def test_metaplex_data(self, erc20_spl):
         metaplex.wait_account_info(self.sol_client, erc20_spl.token_mint.pubkey)
         metadata = metaplex.get_metadata(self.sol_client, erc20_spl.token_mint.pubkey)
         assert metadata["data"]["name"] == erc20_spl.name
         assert metadata["data"]["symbol"] == erc20_spl.symbol
-        assert metadata["is_mutable"] is True
 
     @pytest.mark.parametrize("mintable", [True, False])
     def test_balanceOf(self, erc20_spl, erc20_spl_mintable, mintable):

--- a/integration/tests/basic/erc/test_ERC721.py
+++ b/integration/tests/basic/erc/test_ERC721.py
@@ -58,7 +58,6 @@ class TestERC721:
         assert metadata["mint"] == solana_acc.encode("utf-8")
         assert metadata["data"]["name"] == "Metaplex"
         assert metadata["data"]["symbol"] == "MPL"
-        assert metadata["is_mutable"] is False
 
     def test_mint(self, erc721):
         seed = self.web3_client.text_to_bytes32(gen_hash_of_block(8))


### PR DESCRIPTION
This is required to update Metaplex library on NeonEVM side