### PR TITLE
NDEV-2740: Fix PermissionError: [Errno 13] Permission denied: '/root/.solcx/solc-v0.8.0'

### DIFF
--- a/integration/tests/basic/test_contract_reverting.py
+++ b/integration/tests/basic/test_contract_reverting.py
@@ -36,10 +36,7 @@ class TestContractReverting:
 
     @pytest.fixture(scope="class")
     def solc_version(self) -> Version:
-        version = "0.7.0"
-        if version not in [str(v) for v in solcx.get_installed_solc_versions()]:
-            solcx.install_solc(version)
-        return Version(version)
+        return solcx.install_solc("0.7.0")
 
     def test_constructor_raises_string_based_error(self, solc_version):
         contract = """

--- a/integration/tests/neon_evm/utils/contract.py
+++ b/integration/tests/neon_evm/utils/contract.py
@@ -28,8 +28,7 @@ def get_contract_bin(
         else:
             contract_name = contract.rsplit(".", 1)[0]
 
-    if version not in [str(v) for v in solcx.get_installed_solc_versions()]:
-        solcx.install_solc(version)
+    solcx.install_solc(version)
 
     contract_path = (pathlib.Path.cwd() / "contracts" / "neon_evm" / f"{contract}").absolute()
     if not contract_path.exists():

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -36,8 +36,7 @@ def get_contract_interface(
         else:
             contract_name = contract.rsplit(".", 1)[0]
 
-    if version not in [str(v) for v in solcx.get_installed_solc_versions()]:
-        solcx.install_solc(version)
+    solcx.install_solc(version)
     if contract.startswith("/"):
         contract_path = pathlib.Path(contract)
     else:


### PR DESCRIPTION
There is a possible race condition between when `solcx.get_installed_solc_versions()` detects a solc version as present (it checks for existence of the file) and the time when it actually finishes downloading.

So one process can see the file as present, even the full download of the compiler is not finished yet.

`solcx.install_solc(version)` also checks if the version is already installed and if it is, it does nothing. The check inside `solcx.install_solc(version)` is protected by the same process lock used when installing the solc version, so the race condition should not happen anymore.

This is a potential fix for errors like this: https://github.com/neonlabsorg/proxy-model.py/actions/runs/8201469915/job/22430563938