### PR TITLE
NDEV-2747: Fix tracer CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,7 +79,7 @@ def pytest_configure(config: Config):
         environments = json.load(f)
     assert network_name in environments, f"Environment {network_name} doesn't exist in envs.json"
     env = environments[network_name]
-    if network_name == "devnet":
+    if network_name in ["devnet", "tracer_ci"]:
         for solana_env_var in solana_url_env_vars:
             if solana_env_var in os.environ and os.environ[solana_env_var]:
                 env["solana_url"] = os.environ.get(solana_env_var)

--- a/envs.json
+++ b/envs.json
@@ -314,7 +314,7 @@
     "network_ids": {
       "neon": 245022926
     },
-    "solana_url": "https://api.devnet.solana.com",
+    "solana_url": "http://neon-solrpc-devnet-lb-1.solana.p2p.org/0LcGBYwNa9b0ifu7odnVPEF9TiYHQUXfOuxrTXlH",
     "faucet_url": "http://3.13.67.238/request_neon",
     "neonpass_url": "http://devnet.neonpass.live",
     "tracer_url": "http://neon-rpc:9090",

--- a/envs.json
+++ b/envs.json
@@ -314,7 +314,7 @@
     "network_ids": {
       "neon": 245022926
     },
-    "solana_url": "http://neon-solrpc-devnet-lb-1.solana.p2p.org/0LcGBYwNa9b0ifu7odnVPEF9TiYHQUXfOuxrTXlH",
+    "solana_url": "https://api.devnet.solana.com",
     "faucet_url": "http://3.13.67.238/request_neon",
     "neonpass_url": "http://devnet.neonpass.live",
     "tracer_url": "http://neon-rpc:9090",

--- a/envs.json
+++ b/envs.json
@@ -310,7 +310,7 @@
   },
   "tracer_ci": {
     "evm_loader": "eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU",
-    "proxy_url": "https://ch2-graph.neontest.xyz/solana",
+    "proxy_url": "https://devnet.neonevm.org/",
     "network_ids": {
       "neon": 245022926
     },

--- a/integration/tests/tracer/test_tracer_debug_methods.py
+++ b/integration/tests/tracer/test_tracer_debug_methods.py
@@ -51,12 +51,12 @@ class TestTracerDebugMethods:
         tx_hash = receipt["transactionHash"].hex()
 
         wait_condition(
-            lambda: self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])["result"] is not None,
-            timeout_sec=120,
+            lambda: self.web3_client.get_transaction_by_hash(tx_hash) is not None,
+            timeout_sec=10,
         )
-        tx_info = self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])
+        tx_info = self.web3_client.get_transaction_by_hash(tx_hash)
 
-        response = self.tracer_api.send_rpc(method="debug_traceCall", params=[{}, tx_info["result"]["blockNumber"]])
+        response = self.tracer_api.send_rpc(method="debug_traceCall", params=[{}, hex(tx_info["blockNumber"])])
 
         assert "error" not in response, "Error in response"
         self.validate_response_result(response)
@@ -69,26 +69,26 @@ class TestTracerDebugMethods:
         tx_hash = receipt["transactionHash"].hex()
 
         wait_condition(
-            lambda: self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])["result"] is not None,
-            timeout_sec=120,
+            lambda: self.web3_client.get_transaction_by_hash(tx_hash) is not None,
+            timeout_sec=10,
         )
-        tx_info = self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])
+        tx_info = self.web3_client.get_transaction_by_hash(tx_hash)
 
         params = [
             {
-                "to": tx_info["result"]["to"],
-                "from": tx_info["result"]["from"],
-                "gas": tx_info["result"]["gas"],
-                "gasPrice": tx_info["result"]["gasPrice"],
-                "value": tx_info["result"]["value"],
-                "data": tx_info["result"]["input"],
+                "to": tx_info["to"],
+                "from": tx_info["from"],
+                "gas": hex(tx_info["gas"]),
+                "gasPrice": hex(tx_info["gasPrice"]),
+                "value": hex(tx_info["value"]),
+                "data": tx_info["input"].hex(),
             },
-            tx_info["result"]["blockNumber"],
+            hex(tx_info["blockNumber"]),
         ]
 
         wait_condition(
             lambda: self.tracer_api.send_rpc(method="debug_traceCall", params=params)["result"] is not None,
-            timeout_sec=120,
+            timeout_sec=10,
         )
         response = self.tracer_api.send_rpc(method="debug_traceCall", params=params)
         assert "error" not in response, "Error in response"
@@ -103,26 +103,26 @@ class TestTracerDebugMethods:
         tx_hash = receipt["transactionHash"].hex()
 
         wait_condition(
-            lambda: self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])["result"] is not None,
-            timeout_sec=120,
+            lambda: self.web3_client.get_transaction_by_hash(tx_hash) is not None,
+            timeout_sec=10,
         )
-        tx_info = self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])
+        tx_info = self.web3_client.get_transaction_by_hash(tx_hash)
 
         params = [
             {
-                "to": tx_info["result"]["to"],
-                "from": tx_info["result"]["from"],
-                "gas": tx_info["result"]["gas"],
-                "gasPrice": tx_info["result"]["gasPrice"],
-                "value": tx_info["result"]["value"],
-                "data": tx_info["result"]["input"],
+                "to": tx_info["to"],
+                "from": tx_info["from"],
+                "gas": hex(tx_info["gas"]),
+                "gasPrice": hex(tx_info["gasPrice"]),
+                "value": hex(tx_info["value"]),
+                "data": tx_info["input"].hex(),
             },
-            tx_info["result"]["blockNumber"],
+            hex(tx_info["blockNumber"]),
         ]
 
         wait_condition(
             lambda: self.tracer_api.send_rpc(method="debug_traceCall", params=params)["result"] is not None,
-            timeout_sec=120,
+            timeout_sec=10,
         )
 
         response = self.tracer_api.send_rpc(method="debug_traceCall", params=params)

--- a/integration/tests/tracer/test_tracer_debug_methods.py
+++ b/integration/tests/tracer/test_tracer_debug_methods.py
@@ -196,11 +196,11 @@ class TestTracerDebugMethods:
                 "result"
             ]
             is not None,
-            timeout_sec=120,
+            timeout_sec=10,
         )
         response = self.tracer_api.send_rpc(method="debug_traceBlockByNumber", params=[hex(receipt["blockNumber"])])
         assert "error" not in response, "Error in response"
-        assert tx_hash == response["result"][0]["txHash"]
+        assert tx_hash in map(lambda v: v["txHash"], response["result"])
         self.validate_response_result(response["result"][0])
 
     @pytest.mark.parametrize("number", [190, "", "3f08", "num", "0x"])

--- a/integration/tests/tracer/test_tracer_debug_methods.py
+++ b/integration/tests/tracer/test_tracer_debug_methods.py
@@ -252,7 +252,7 @@ class TestTracerDebugMethods:
         )
         response = self.tracer_api.send_rpc(method="debug_traceBlockByHash", params=[receipt["blockHash"].hex()])
         assert "error" not in response, "Error in response"
-        assert tx_hash == response["result"][0]["txHash"]
+        assert tx_hash in map(lambda v: v["txHash"], response["result"])
 
         self.validate_response_result(response["result"][0])
 


### PR DESCRIPTION
- Updated tracer-api tests to use `"proxy_url": "https://devnet.neonevm.org/"` instead of `"proxy_url": "https://ch2-graph.neontest.xyz/solana"`.
- Updates tracer-api tests to use `"solana_url": "http://neon-solrpc-devnet-lb-1.solana.p2p.org/0LcGBYwNa9b0ifu7odnVPEF9TiYHQUXfOuxrTXlH"` in order to avoid rate limit errors of `"solana_url": "https://api.devnet.solana.com"`
- Fixed `test_debug_trace_block_by_number` and `test_debug_trace_block_by_hash` tests to check the `tx_hash` is present in the block, instead of checking it to be the first one. A Solana (Neon) block can contain more than one Neon transaction.
- Updated other tests to use `self.web3_client.get_transaction_by_hash(tx_hash)` instead of `self.tracer_api.send_rpc(method="eth_getTransactionByHash", params=[tx_hash])`, because `eth_getTransactionByHash` is an RPC method implemented by Neon Proxy and not by Tracer API.