### PR TITLE
Ndev 3750

### DIFF
--- a/contracts/common/Revision.sol
+++ b/contracts/common/Revision.sol
@@ -51,6 +51,7 @@ contract RevisionChangerCaller {
     function callRevisionChangerMethods(uint256 n) public {
         rch.powNumberInnerAndRollback(n);
         rch.changeGlobalVarB(n);
+        checkGlobalVarBChanged(n);
         rch.powNumberOuterAndRollback(n);
     }
 
@@ -58,6 +59,17 @@ contract RevisionChangerCaller {
     // we need to have a func with the same signature as in the RevisionChanger contract
     function changeGlobalVarB(uint256 n) public {
         bytes32[64] memory b = rch.getVarB();
-        b[0] = bytes32(abi.encodePacked(n));
+        b[0] = bytes32(abi.encodePacked(n+n));
+        require(false, "Wrong method taken from caller contract");
+    }
+
+    function checkGlobalVarBChanged(uint256 n) public {
+        bytes32[64] memory b = rch.getVarB();
+        for (uint i = 0; i < 64; i++) {
+            require(
+                b[i] == bytes32(abi.encodePacked(n)),
+                "Global var is not changed"
+            );
+        }
     }
 }

--- a/contracts/common/Revision.sol
+++ b/contracts/common/Revision.sol
@@ -6,6 +6,10 @@ contract RevisionChanger {
     bytes32[64] public b;
     uint256 public number_outer_contract_scope = 2;
 
+    function getVarB() public returns (bytes32[64] memory) {
+        return b;
+    }
+
     function powNumberInnerAndRollback(uint256 n) public {
         require(n > 0, "Exponent should be > 0");
 
@@ -48,5 +52,12 @@ contract RevisionChangerCaller {
         rch.powNumberInnerAndRollback(n);
         rch.changeGlobalVarB(n);
         rch.powNumberOuterAndRollback(n);
+    }
+
+    // we do not change rch.b value here
+    // we need to have a func with the same signature as in the RevisionChanger contract
+    function changeGlobalVarB(uint256 n) public {
+        bytes32[64] memory b = rch.getVarB();
+        b[0] = bytes32(abi.encodePacked(n));
     }
 }

--- a/contracts/common/Revision.sol
+++ b/contracts/common/Revision.sol
@@ -31,9 +31,10 @@ contract RevisionChanger {
         }
     }
 
-    function changeGlobalVarB(uint i) public {
-        bytes32 a = 0x68656c6c3f000000000000000000000000000000000000000000000000000000;
-        b[i] = bytes32(a);
+    function changeGlobalVarB(uint256 n) public {
+        for (uint i = 0; i < 64; i++) {
+            b[i] = bytes32(abi.encodePacked(n));
+        }
     }
 }
 
@@ -45,7 +46,7 @@ contract RevisionChangerCaller {
 
     function callRevisionChangerMethods(uint256 n) public {
         rch.powNumberInnerAndRollback(n);
-        rch.changeGlobalVarB(0);
+        rch.changeGlobalVarB(n);
         rch.powNumberOuterAndRollback(n);
     }
 }

--- a/contracts/common/Revision.sol
+++ b/contracts/common/Revision.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.12;
 
 contract RevisionChanger {
-
     uint256 public number_inner_contract_scope = 1;
     bytes32[64] public b;
     uint256 public number_outer_contract_scope = 2;
@@ -15,9 +14,8 @@ contract RevisionChanger {
 
         for (uint i = 0; i < n; i++) {
             computedValue *= original;
-            number_inner_contract_scope=computedValue;
+            number_inner_contract_scope = computedValue;
         }
-
         number_inner_contract_scope = original;
     }
 
@@ -29,10 +27,35 @@ contract RevisionChanger {
 
         for (uint i = 0; i < n; i++) {
             computedValue *= original;
-            number_outer_contract_scope=computedValue;
+            number_outer_contract_scope = computedValue;
         }
+    }
 
-        number_outer_contract_scope = original;
+    function changeGlobalVarB(uint i) public {
+        bytes32 a = 0x68656c6c3f000000000000000000000000000000000000000000000000000000;
+        b[i] = bytes32(a);
     }
 }
 
+contract RevisionChangerCaller {
+    RevisionChanger rch;
+    constructor(address revisionChangerAddress) {
+        rch = RevisionChanger(revisionChangerAddress);
+    }
+
+    function executeIterativeActionsAndChangeData(
+        uint256 n,
+        uint256 x,
+        uint256 y
+    ) public {
+        rch.powNumberInnerAndRollback(n);
+        rch.changeGlobalVarB(0);
+        rch.powNumberOuterAndRollback(n);
+        rch.changeGlobalVarB(5);
+        uint z = x;
+        while (x < y) {
+            z++;
+            x = z;
+        }
+    }
+}

--- a/contracts/common/Revision.sol
+++ b/contracts/common/Revision.sol
@@ -43,19 +43,9 @@ contract RevisionChangerCaller {
         rch = RevisionChanger(revisionChangerAddress);
     }
 
-    function executeIterativeActionsAndChangeData(
-        uint256 n,
-        uint256 x,
-        uint256 y
-    ) public {
+    function callRevisionChangerMethods(uint256 n) public {
         rch.powNumberInnerAndRollback(n);
         rch.changeGlobalVarB(0);
         rch.powNumberOuterAndRollback(n);
-        rch.changeGlobalVarB(5);
-        uint z = x;
-        while (x < y) {
-            z++;
-            x = z;
-        }
     }
 }

--- a/contracts/neon_evm/rw_lock.sol
+++ b/contracts/neon_evm/rw_lock.sol
@@ -49,19 +49,6 @@ contract rw_lock {
             n = n + 1;
         }
     }
-
-    function execute_iterative_actions_and_change_data( uint x, uint y, uint resize) public {
-        uint n = 0;
-        while (n < resize){
-            data[msg.sender][n] = uint256(n);
-            n = n + 1;
-        }
-        uint z = x;
-        while (x < y) {
-            z++;
-            x = z;
-        }
-    }
 }
 
 
@@ -92,7 +79,4 @@ contract rw_lock_caller {
        return rw.update_storage_map_with_salt(resize, salt);
     }
 
-    function call_nested_contracts_and_change_data(uint x, uint y, uint resize) public {
-        rw.execute_iterative_actions_and_change_data(x, y, resize);
-    }
 }

--- a/contracts/neon_evm/rw_lock.sol
+++ b/contracts/neon_evm/rw_lock.sol
@@ -50,6 +50,18 @@ contract rw_lock {
         }
     }
 
+    function execute_iterative_actions_and_change_data( uint x, uint y, uint resize) public {
+        uint n = 0;
+        while (n < resize){
+            data[msg.sender][n] = uint256(n);
+            n = n + 1;
+        }
+        uint z = x;
+        while (x < y) {
+            z++;
+            x = z;
+        }
+    }
 }
 
 
@@ -78,5 +90,9 @@ contract rw_lock_caller {
 
     function update_storage_map_with_salt(uint resize, uint salt) public {
        return rw.update_storage_map_with_salt(resize, salt);
-     }
+    }
+
+    function call_nested_contracts_and_change_data(uint x, uint y, uint resize) public {
+        rw.execute_iterative_actions_and_change_data(x, y, resize);
+    }
 }

--- a/integration/tests/neon_evm/test_revision.py
+++ b/integration/tests/neon_evm/test_revision.py
@@ -878,3 +878,167 @@ class TestAccountRevision:
 
         assert balance_before == balance_after
         assert revision_before == revision_after
+
+    def test_1_user_2_parallel_trx_of_one_contract_with_nested_call(
+        self,
+        operator_keypair,
+        treasury_pool,
+        neon_api_client,
+        session_user,
+        rw_lock_contract,
+        evm_loader,
+        holder_acc,
+        sol_client,
+    ):
+        call_params = [0, 3000, 5]
+        additional_accounts = [session_user.balance_account_address, rw_lock_contract.solana_address]
+        operator_balance_pubkey = evm_loader.get_operator_balance_pubkey(operator_keypair)
+
+        emulate_result = neon_api_client.emulate_contract_call(
+            session_user.eth_address.hex(),
+            rw_lock_contract.eth_address.hex(),
+            "call_nested_contracts_and_change_data(uint,uint,uint)",
+            call_params,
+        )
+
+        acc_from_emulation = [Pubkey.from_string(item["pubkey"]) for item in emulate_result["solana_accounts"]]
+        data_accounts = set(acc_from_emulation) - set(additional_accounts)
+
+        signed_tx1 = make_contract_call_trx(
+            evm_loader,
+            session_user,
+            rw_lock_contract,
+            "call_nested_contracts_and_change_data(uint,uint,uint)",
+            call_params,
+        )
+        evm_loader.write_transaction_to_holder_account(signed_tx1, holder_acc, operator_keypair)
+
+        evm_loader.send_transaction_step_from_account(
+            operator_keypair,
+            operator_balance_pubkey,
+            treasury_pool,
+            holder_acc,
+            acc_from_emulation,
+            EVM_STEPS,
+            operator_keypair,
+        )
+        evm_loader.send_transaction_step_from_account(
+            operator_keypair,
+            operator_balance_pubkey,
+            treasury_pool,
+            holder_acc,
+            acc_from_emulation,
+            EVM_STEPS,
+            operator_keypair,
+        )
+
+        for _ in range(2):
+            holder_acc_for_trx_from_instr = evm_loader.create_holder(operator_keypair)
+            signed_tx2 = make_contract_call_trx(
+                evm_loader,
+                session_user,
+                rw_lock_contract,
+                "call_nested_contracts_and_change_data(uint,uint,uint)",
+                call_params,
+            )
+            resp = evm_loader.execute_trx_from_instruction(
+                operator_keypair,
+                holder_acc_for_trx_from_instr,
+                treasury_pool.account,
+                treasury_pool.buffer,
+                signed_tx2,
+                acc_from_emulation,
+            )
+            check_transaction_logs_have_text(solana_client=sol_client, trx=resp, text="exit_status=0x11")
+
+        resp = evm_loader.send_transaction_step_from_account(
+            operator_keypair,
+            operator_balance_pubkey,
+            treasury_pool,
+            holder_acc,
+            acc_from_emulation,
+            EVM_STEPS,
+            operator_keypair,
+        )
+
+        check_transaction_logs_have_text(solana_client=sol_client, trx=resp, text="exit_status=0x11")
+        check_holder_account_tag(
+            solana_client=sol_client,
+            storage_account=holder_acc,
+            layout=FINALIZED_STORAGE_ACCOUNT_INFO_LAYOUT,
+            expected_tag=TAG_FINALIZED_STATE,
+        )
+
+        for acc in data_accounts:
+            if evm_loader.get_solana_balance(acc) > 0:
+                data_acc_revision_after = evm_loader.get_data_account_revision(acc)
+                assert data_acc_revision_after == 3
+
+    def test_2_users_call_one_contract_with_nested_call(
+        self,
+        user_account,
+        evm_loader,
+        operator_keypair,
+        treasury_pool,
+        new_holder_acc,
+        holder_acc,
+        neon_api_client,
+        rw_lock_contract,
+        session_user,
+        sol_client,
+    ):
+        user1 = session_user
+        user2 = user_account
+        holder1 = holder_acc
+        holder2 = new_holder_acc
+        call_params = [0, 3000, 5]
+
+        operator_balance_pubkey = evm_loader.get_operator_balance_pubkey(operator_keypair)
+
+        def send_transaction_steps(holder_account, accounts):
+            return evm_loader.send_transaction_step_from_account(
+                operator_keypair,
+                operator_balance_pubkey,
+                treasury_pool,
+                holder_account,
+                accounts,
+                EVM_STEPS,
+                operator_keypair,
+            )
+
+        emulate_result1 = neon_api_client.emulate_contract_call(
+            user1.eth_address.hex(),
+            rw_lock_contract.eth_address.hex(),
+            "call_nested_contracts_and_change_data(uint,uint,uint)",
+            call_params,
+        )
+
+        acc_from_emulation1 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result1["solana_accounts"]]
+        signed_tx1 = make_contract_call_trx(
+            evm_loader, user1, rw_lock_contract, "call_nested_contracts_and_change_data(uint,uint,uint)", call_params
+        )
+
+        evm_loader.write_transaction_to_holder_account(signed_tx1, holder1, operator_keypair)
+
+        emulate_result2 = neon_api_client.emulate_contract_call(
+            user2.eth_address.hex(),
+            rw_lock_contract.eth_address.hex(),
+            "call_nested_contracts_and_change_data(uint,uint,uint)",
+            call_params,
+        )
+        acc_from_emulation2 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result2["solana_accounts"]]
+        signed_tx2 = make_contract_call_trx(
+            evm_loader, user2, rw_lock_contract, "call_nested_contracts_and_change_data(uint,uint,uint)", call_params
+        )
+        evm_loader.write_transaction_to_holder_account(signed_tx2, holder2, operator_keypair)
+
+        send_transaction_steps(holder1, acc_from_emulation1)
+        send_transaction_steps(holder2, acc_from_emulation2)
+        send_transaction_steps(holder1, acc_from_emulation1)
+        send_transaction_steps(holder2, acc_from_emulation2)
+        resp1 = send_transaction_steps(holder1, acc_from_emulation1)
+        send_transaction_steps(holder2, acc_from_emulation2)
+        check_transaction_logs_have_text(solana_client=sol_client, trx=resp1, text="exit_status=0x11")
+
+        resp2 = send_transaction_steps(holder2, acc_from_emulation2)
+        check_transaction_logs_have_text(solana_client=sol_client, trx=resp2, text="exit_status=0x11")

--- a/integration/tests/neon_evm/test_revision.py
+++ b/integration/tests/neon_evm/test_revision.py
@@ -978,7 +978,7 @@ class TestAccountRevision:
         )
         evm_loader.write_transaction_to_holder_account(signed_tx2, holder2, operator_keypair)
 
-        for _ in range(3):
+        for _ in range(10):
             send_transaction_steps(holder1, acc_from_emulation1)
 
         resp2 = evm_loader.execute_transaction_steps_from_account(
@@ -995,7 +995,7 @@ class TestAccountRevision:
         contract_revision_caller_after = evm_loader.get_contract_account_revision(
             revision_contract_caller.solana_address
         )
-        assert contract_revision_before == contract_revision_after - 1
+        assert contract_revision_before == contract_revision_after - 2
         assert contract_revision_caller_before == contract_revision_caller_after
 
         data_accounts = set(acc_from_emulation1) - set(additional_accounts)

--- a/integration/tests/neon_evm/test_revision.py
+++ b/integration/tests/neon_evm/test_revision.py
@@ -949,7 +949,6 @@ class TestAccountRevision:
             "callRevisionChangerMethods(uint256)",
             [10],
         )
-        print("Emulation result 1 trx: ", emulate_result1)
 
         acc_from_emulation1 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result1["solana_accounts"]]
         signed_tx1 = make_contract_call_trx(
@@ -967,7 +966,7 @@ class TestAccountRevision:
             "callRevisionChangerMethods(uint256)",
             [4],
         )
-        print("Emulation result 2 trx: ", emulate_result2)
+
         acc_from_emulation2 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result2["solana_accounts"]]
         signed_tx2 = make_contract_call_trx(
             evm_loader,

--- a/integration/tests/neon_evm/test_revision.py
+++ b/integration/tests/neon_evm/test_revision.py
@@ -946,48 +946,48 @@ class TestAccountRevision:
         emulate_result1 = neon_api_client.emulate_contract_call(
             user1.eth_address.hex(),
             revision_contract_caller.eth_address.hex(),
-            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
-            [10, 0, 3000],
+            "callRevisionChangerMethods(uint256)",
+            [10],
         )
+        print("Emulation result 1 trx: ", emulate_result1)
 
         acc_from_emulation1 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result1["solana_accounts"]]
         signed_tx1 = make_contract_call_trx(
             evm_loader,
             user1,
             revision_contract_caller,
-            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
-            [10, 0, 3000],
+            "callRevisionChangerMethods(uint256)",
+            [10],
         )
         evm_loader.write_transaction_to_holder_account(signed_tx1, holder1, operator_keypair)
 
         emulate_result2 = neon_api_client.emulate_contract_call(
             user2.eth_address.hex(),
             revision_contract_caller.eth_address.hex(),
-            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
-            [4, 0, 3000],
+            "callRevisionChangerMethods(uint256)",
+            [4],
         )
+        print("Emulation result 2 trx: ", emulate_result2)
         acc_from_emulation2 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result2["solana_accounts"]]
         signed_tx2 = make_contract_call_trx(
             evm_loader,
             user2,
             revision_contract_caller,
-            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
-            [4, 0, 3000],
+            "callRevisionChangerMethods(uint256)",
+            [4],
         )
         evm_loader.write_transaction_to_holder_account(signed_tx2, holder2, operator_keypair)
 
-        for i in range(220):
+        for _ in range(3):
             send_transaction_steps(holder1, acc_from_emulation1)
-            send_transaction_steps(holder2, acc_from_emulation2)
 
-        send_transaction_steps(holder1, acc_from_emulation1)
-        resp1 = send_transaction_steps(holder1, acc_from_emulation1)
+        resp2 = evm_loader.execute_transaction_steps_from_account(
+            operator_keypair, treasury_pool, holder2, acc_from_emulation2
+        )
+        check_transaction_logs_have_text(solana_client=sol_client, trx=resp2, text="exit_status=0x11")
 
-        check_holder_account_tag(
-            solana_client=sol_client,
-            storage_account=holder1,
-            layout=FINALIZED_STORAGE_ACCOUNT_INFO_LAYOUT,
-            expected_tag=TAG_FINALIZED_STATE,
+        resp1 = evm_loader.execute_transaction_steps_from_account(
+            operator_keypair, treasury_pool, holder1, acc_from_emulation1
         )
         check_transaction_logs_have_text(solana_client=sol_client, trx=resp1, text="exit_status=0x11")
 
@@ -1000,22 +1000,5 @@ class TestAccountRevision:
 
         data_accounts = set(acc_from_emulation1) - set(additional_accounts)
         for acc in data_accounts:
-            if evm_loader.get_solana_balance(acc) > 0:
-                data_acc_revision_after = evm_loader.get_data_account_revision(acc)
-                assert data_acc_revision_after == 2
-
-        for i in range(219):
-            send_transaction_steps(holder2, acc_from_emulation2)
-        resp2 = send_transaction_steps(holder2, acc_from_emulation2)
-        check_holder_account_tag(
-            solana_client=sol_client,
-            storage_account=holder2,
-            layout=FINALIZED_STORAGE_ACCOUNT_INFO_LAYOUT,
-            expected_tag=TAG_FINALIZED_STATE,
-        )
-        check_transaction_logs_have_text(solana_client=sol_client, trx=resp2, text="exit_status=0x11")
-
-        for acc in data_accounts:
-            if evm_loader.get_solana_balance(acc) > 0:
-                data_acc_revision_after = evm_loader.get_data_account_revision(acc)
-                assert data_acc_revision_after == 3
+            data_acc_revision_after = evm_loader.get_data_account_revision(acc)
+            assert data_acc_revision_after == 3

--- a/integration/tests/neon_evm/test_revision.py
+++ b/integration/tests/neon_evm/test_revision.py
@@ -1,4 +1,5 @@
 import pytest
+import eth_abi
 from solana.rpc.core import RPCException as SolanaRPCException
 from solders.pubkey import Pubkey
 
@@ -27,6 +28,29 @@ class TestAccountRevision:
             neon_api_client,
             treasury_pool,
             contract_name="RevisionChanger",
+            version="0.8.12",
+        )
+
+    @pytest.fixture(scope="class")
+    def revision_contract_caller(
+        self,
+        request,
+        revision_contract,
+        evm_loader,
+        operator_keypair,
+        sender_with_tokens,
+        neon_api_client,
+        treasury_pool,
+    ):
+        constructor_args = eth_abi.encode(["address"], [revision_contract.eth_address.hex()])
+        return evm_loader.deploy_contract(
+            operator_keypair,
+            sender_with_tokens,
+            "common/Revision.sol",
+            neon_api_client,
+            treasury_pool,
+            encoded_args=constructor_args,
+            contract_name="RevisionChangerCaller",
             version="0.8.12",
         )
 
@@ -879,101 +903,6 @@ class TestAccountRevision:
         assert balance_before == balance_after
         assert revision_before == revision_after
 
-    def test_1_user_2_parallel_trx_of_one_contract_with_nested_call(
-        self,
-        operator_keypair,
-        treasury_pool,
-        neon_api_client,
-        session_user,
-        rw_lock_contract,
-        evm_loader,
-        holder_acc,
-        sol_client,
-    ):
-        call_params = [0, 3000, 5]
-        additional_accounts = [session_user.balance_account_address, rw_lock_contract.solana_address]
-        operator_balance_pubkey = evm_loader.get_operator_balance_pubkey(operator_keypair)
-
-        emulate_result = neon_api_client.emulate_contract_call(
-            session_user.eth_address.hex(),
-            rw_lock_contract.eth_address.hex(),
-            "call_nested_contracts_and_change_data(uint,uint,uint)",
-            call_params,
-        )
-
-        acc_from_emulation = [Pubkey.from_string(item["pubkey"]) for item in emulate_result["solana_accounts"]]
-        data_accounts = set(acc_from_emulation) - set(additional_accounts)
-
-        signed_tx1 = make_contract_call_trx(
-            evm_loader,
-            session_user,
-            rw_lock_contract,
-            "call_nested_contracts_and_change_data(uint,uint,uint)",
-            call_params,
-        )
-        evm_loader.write_transaction_to_holder_account(signed_tx1, holder_acc, operator_keypair)
-
-        evm_loader.send_transaction_step_from_account(
-            operator_keypair,
-            operator_balance_pubkey,
-            treasury_pool,
-            holder_acc,
-            acc_from_emulation,
-            EVM_STEPS,
-            operator_keypair,
-        )
-        evm_loader.send_transaction_step_from_account(
-            operator_keypair,
-            operator_balance_pubkey,
-            treasury_pool,
-            holder_acc,
-            acc_from_emulation,
-            EVM_STEPS,
-            operator_keypair,
-        )
-
-        for _ in range(2):
-            holder_acc_for_trx_from_instr = evm_loader.create_holder(operator_keypair)
-            signed_tx2 = make_contract_call_trx(
-                evm_loader,
-                session_user,
-                rw_lock_contract,
-                "call_nested_contracts_and_change_data(uint,uint,uint)",
-                call_params,
-            )
-            resp = evm_loader.execute_trx_from_instruction(
-                operator_keypair,
-                holder_acc_for_trx_from_instr,
-                treasury_pool.account,
-                treasury_pool.buffer,
-                signed_tx2,
-                acc_from_emulation,
-            )
-            check_transaction_logs_have_text(solana_client=sol_client, trx=resp, text="exit_status=0x11")
-
-        resp = evm_loader.send_transaction_step_from_account(
-            operator_keypair,
-            operator_balance_pubkey,
-            treasury_pool,
-            holder_acc,
-            acc_from_emulation,
-            EVM_STEPS,
-            operator_keypair,
-        )
-
-        check_transaction_logs_have_text(solana_client=sol_client, trx=resp, text="exit_status=0x11")
-        check_holder_account_tag(
-            solana_client=sol_client,
-            storage_account=holder_acc,
-            layout=FINALIZED_STORAGE_ACCOUNT_INFO_LAYOUT,
-            expected_tag=TAG_FINALIZED_STATE,
-        )
-
-        for acc in data_accounts:
-            if evm_loader.get_solana_balance(acc) > 0:
-                data_acc_revision_after = evm_loader.get_data_account_revision(acc)
-                assert data_acc_revision_after == 3
-
     def test_2_users_call_one_contract_with_nested_call(
         self,
         user_account,
@@ -983,17 +912,25 @@ class TestAccountRevision:
         new_holder_acc,
         holder_acc,
         neon_api_client,
-        rw_lock_contract,
+        revision_contract,
+        revision_contract_caller,
         session_user,
         sol_client,
     ):
+        contract_revision_before = evm_loader.get_contract_account_revision(revision_contract.solana_address)
+        contract_revision_caller_before = evm_loader.get_contract_account_revision(
+            revision_contract_caller.solana_address
+        )
         user1 = session_user
         user2 = user_account
         holder1 = holder_acc
         holder2 = new_holder_acc
-        call_params = [0, 3000, 5]
-
         operator_balance_pubkey = evm_loader.get_operator_balance_pubkey(operator_keypair)
+        additional_accounts = [
+            session_user.balance_account_address,
+            revision_contract.solana_address,
+            revision_contract_caller.solana_address,
+        ]
 
         def send_transaction_steps(holder_account, accounts):
             return evm_loader.send_transaction_step_from_account(
@@ -1008,37 +945,77 @@ class TestAccountRevision:
 
         emulate_result1 = neon_api_client.emulate_contract_call(
             user1.eth_address.hex(),
-            rw_lock_contract.eth_address.hex(),
-            "call_nested_contracts_and_change_data(uint,uint,uint)",
-            call_params,
+            revision_contract_caller.eth_address.hex(),
+            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
+            [10, 0, 3000],
         )
 
         acc_from_emulation1 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result1["solana_accounts"]]
         signed_tx1 = make_contract_call_trx(
-            evm_loader, user1, rw_lock_contract, "call_nested_contracts_and_change_data(uint,uint,uint)", call_params
+            evm_loader,
+            user1,
+            revision_contract_caller,
+            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
+            [10, 0, 3000],
         )
-
         evm_loader.write_transaction_to_holder_account(signed_tx1, holder1, operator_keypair)
 
         emulate_result2 = neon_api_client.emulate_contract_call(
             user2.eth_address.hex(),
-            rw_lock_contract.eth_address.hex(),
-            "call_nested_contracts_and_change_data(uint,uint,uint)",
-            call_params,
+            revision_contract_caller.eth_address.hex(),
+            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
+            [4, 0, 3000],
         )
         acc_from_emulation2 = [Pubkey.from_string(item["pubkey"]) for item in emulate_result2["solana_accounts"]]
         signed_tx2 = make_contract_call_trx(
-            evm_loader, user2, rw_lock_contract, "call_nested_contracts_and_change_data(uint,uint,uint)", call_params
+            evm_loader,
+            user2,
+            revision_contract_caller,
+            "executeIterativeActionsAndChangeData(uint256,uint256,uint256)",
+            [4, 0, 3000],
         )
         evm_loader.write_transaction_to_holder_account(signed_tx2, holder2, operator_keypair)
 
+        for i in range(220):
+            send_transaction_steps(holder1, acc_from_emulation1)
+            send_transaction_steps(holder2, acc_from_emulation2)
+
         send_transaction_steps(holder1, acc_from_emulation1)
-        send_transaction_steps(holder2, acc_from_emulation2)
-        send_transaction_steps(holder1, acc_from_emulation1)
-        send_transaction_steps(holder2, acc_from_emulation2)
         resp1 = send_transaction_steps(holder1, acc_from_emulation1)
-        send_transaction_steps(holder2, acc_from_emulation2)
+
+        check_holder_account_tag(
+            solana_client=sol_client,
+            storage_account=holder1,
+            layout=FINALIZED_STORAGE_ACCOUNT_INFO_LAYOUT,
+            expected_tag=TAG_FINALIZED_STATE,
+        )
         check_transaction_logs_have_text(solana_client=sol_client, trx=resp1, text="exit_status=0x11")
 
+        contract_revision_after = evm_loader.get_contract_account_revision(revision_contract.solana_address)
+        contract_revision_caller_after = evm_loader.get_contract_account_revision(
+            revision_contract_caller.solana_address
+        )
+        assert contract_revision_before == contract_revision_after - 1
+        assert contract_revision_caller_before == contract_revision_caller_after
+
+        data_accounts = set(acc_from_emulation1) - set(additional_accounts)
+        for acc in data_accounts:
+            if evm_loader.get_solana_balance(acc) > 0:
+                data_acc_revision_after = evm_loader.get_data_account_revision(acc)
+                assert data_acc_revision_after == 2
+
+        for i in range(219):
+            send_transaction_steps(holder2, acc_from_emulation2)
         resp2 = send_transaction_steps(holder2, acc_from_emulation2)
+        check_holder_account_tag(
+            solana_client=sol_client,
+            storage_account=holder2,
+            layout=FINALIZED_STORAGE_ACCOUNT_INFO_LAYOUT,
+            expected_tag=TAG_FINALIZED_STATE,
+        )
         check_transaction_logs_have_text(solana_client=sol_client, trx=resp2, text="exit_status=0x11")
+
+        for acc in data_accounts:
+            if evm_loader.get_solana_balance(acc) > 0:
+                data_acc_revision_after = evm_loader.get_data_account_revision(acc)
+                assert data_acc_revision_after == 3

--- a/integration/tests/neon_evm/test_revision.py
+++ b/integration/tests/neon_evm/test_revision.py
@@ -977,7 +977,8 @@ class TestAccountRevision:
         )
         evm_loader.write_transaction_to_holder_account(signed_tx2, holder2, operator_keypair)
 
-        for _ in range(10):
+        # we need 16 steps to complete trx1
+        for _ in range(14):
             send_transaction_steps(holder1, acc_from_emulation1)
 
         resp2 = evm_loader.execute_transaction_steps_from_account(


### PR DESCRIPTION
evm tag to reproduce the bug: `c619910e2b1492119f809b64640de819dfd5e874`

The test:
There is a contract and a caller contract. I call a method from the first contract inside the second one, this method changes both a data account revision and a contract revision. I added a func with the same signature to the caller contract and I got for `c619910e2b1492119f809b64640de819dfd5e874` tag:
- both trxs are executed successfully (1 trx is interrupted by 2 trx and then it is executed again)
- data account revision is changed only once, but we expect it is changed twice
- contract revision is changed only once, but we expect it is changed twice

It is fixed on latest tag and the test is passed. 
